### PR TITLE
Remove honeypot.io from list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,8 +42,6 @@ Watch The Pitch Doctor's Berlin Pitch video, "[Why you should move your startup 
 
 - [moberries](https://www.moberries.com/)
 
-- [honeypot.io](https://www.honeypot.io/en/)
-
 - [stepstone](https://www.stepstone.de/)
 
 - [talent.io](https://www.talent.io/)


### PR DESCRIPTION
**changes**
Remove honeypot.io from list


Reason,

New Work SE has stopped honeypot.io from 1 January 2025

> the planned discontinuation of Honeypot.

official press release link: https://new-work.se/en/newsroom/press-releases/2024-first-half-of-2024-nwse-restructuring-progressing-well-and-on-schedule